### PR TITLE
Use latest tag, not what is returned by npm

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -22,8 +22,6 @@ jobs:
         id: getVersion
         shell: bash
         run: |
-          # VERSION=$(npm info . --json version | sed -e 's/"//g')
-          # echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "version=${{ github.ref_name }} >> $GITHUB_OUTPUT
       - uses: flowfuse/github-actions-workflows/actions/update-nr-flows@v0.52.0
         with:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -22,8 +22,9 @@ jobs:
         id: getVersion
         shell: bash
         run: |
-          VERSION=$(npm info . --json version | sed -e 's/"//g')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          # VERSION=$(npm info . --json version | sed -e 's/"//g')
+          # echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=${{ github.ref_name }} >> $GITHUB_OUTPUT
       - uses: flowfuse/github-actions-workflows/actions/update-nr-flows@v0.52.0
         with:
           package: '@flowfuse/nr-tools-plugin'


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Comment out the version retrieval commands and set version from github.ref_name.

`npm info version` will return the old version more than likely

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://github.com/FlowFuse/nr-tools-plugin/actions/runs/24089485857/job/70271562820

